### PR TITLE
ci(github): automate release and crates.io publish

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,12 +4,15 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*.*.*'  # Trigger on version tags like v1.2.3
   pull_request:
     branches:
       - main
 
 permissions:
-  contents: read
+  contents: write  # Needed for creating releases
+  packages: write
 
 jobs:
   rust-macos-arm64:
@@ -77,3 +80,23 @@ jobs:
         with:
           name: sps-macos-arm64
           path: ${{ steps.find-binary.outputs.binary_path }}
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ steps.find-binary.outputs.binary_path }}
+          body: |
+            Automated release for ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to crates.io
+        if: startsWith(github.ref, 'refs/tags/')
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Create Conventional Commit Message
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          version=${GITHUB_REF#refs/tags/}
+          echo "feat(release): Release ${version}" > conventional_commit_message.txt


### PR DESCRIPTION
Untested, requires setting `CARGO_REGISTRY_TOKEN` as a repository secret:

- Extend Rust CI workflow to trigger on version tags (v*.*.*).
- Automatically create GitHub Releases with compiled binaries.
- Automatically publish new versions to crates.io.