### PR TITLE
feat(core/cli): add "list" command for the CLI to list all installed formulas and casks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ sps --help
 # Update metadata
 sps update
 
+# List all installed packages
+sps list
+
+# List only installed formulae
+sps list --formula
+
+# List only installed casks
+sps list --cask
+
 # Search for packages
 sps search <formula/cask>
 

--- a/sps/src/cli.rs
+++ b/sps/src/cli.rs
@@ -12,6 +12,7 @@ use crate::cli::search::Search;
 use crate::cli::uninstall::Uninstall;
 use crate::cli::update::Update;
 use crate::cli::upgrade::UpgradeArgs;
+use crate::cli::list::List;
 
 pub mod info;
 pub mod install;
@@ -22,6 +23,7 @@ pub mod status;
 pub mod uninstall;
 pub mod update;
 pub mod upgrade;
+pub mod list;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None, name = "sps", bin_name = "sps")]
@@ -39,7 +41,8 @@ pub struct CliArgs {
 pub enum Command {
     /// Search for available formulas and casks
     Search(Search),
-
+    /// List all installed formulas and casks
+    List(List),
     /// Display information about a formula or cask
     Info(Info),
 
@@ -63,6 +66,7 @@ impl Command {
     pub async fn run(&self, config: &Config, cache: Arc<Cache>) -> Result<()> {
         match self {
             Self::Search(command) => command.run(config, cache).await,
+            Self::List(command) => command.run(config, cache).await,
             Self::Info(command) => command.run(config, cache).await,
             Self::Update(command) => command.run(config, cache).await,
             Self::Install(command) => command.run(config, cache).await,

--- a/sps/src/cli.rs
+++ b/sps/src/cli.rs
@@ -7,15 +7,16 @@ use sps_common::{Cache, Config};
 
 use crate::cli::info::Info;
 use crate::cli::install::InstallArgs;
+use crate::cli::list::List;
 use crate::cli::reinstall::ReinstallArgs;
 use crate::cli::search::Search;
 use crate::cli::uninstall::Uninstall;
 use crate::cli::update::Update;
 use crate::cli::upgrade::UpgradeArgs;
-use crate::cli::list::List;
 
 pub mod info;
 pub mod install;
+pub mod list;
 pub mod reinstall;
 pub mod runner;
 pub mod search;
@@ -23,7 +24,6 @@ pub mod status;
 pub mod uninstall;
 pub mod update;
 pub mod upgrade;
-pub mod list;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None, name = "sps", bin_name = "sps")]

--- a/sps/src/cli/list.rs
+++ b/sps/src/cli/list.rs
@@ -9,62 +9,65 @@ use sps_common::config::Config;
 use sps_common::error::Result;
 use sps_common::formulary::Formulary;
 use sps_core::installed::{get_installed_packages, PackageType};
+use sps_core::InstalledPackageInfo;
 
 #[derive(Args, Debug)]
 pub struct List {
-    /// Show all installed versions, not just the latest for each name
-    #[arg(long)]
-    pub all: bool,
+    /// Show only formulas
+    #[arg(long = "formula")]
+    pub formula_only: bool,
+    /// Show only casks
+    #[arg(long = "cask")]
+    pub cask_only: bool,
 }
 
 impl List {
     pub async fn run(&self, config: &Config, cache: Arc<Cache>) -> Result<()> {
         let installed = get_installed_packages(config).await?;
-        let mut formulas = Vec::new();
-        let mut casks = Vec::new();
-        if self.all {
-            // Show all installed versions
-            for pkg in &installed {
-                match pkg.pkg_type {
-                    PackageType::Formula => formulas.push(pkg),
-                    PackageType::Cask => casks.push(pkg),
-                }
-            }
-        } else {
-            // Only show the latest version for each name
-            use std::collections::HashMap;
-            let mut formula_map: HashMap<&str, &sps_core::installed::InstalledPackageInfo> =
-                HashMap::new();
-            let mut cask_map: HashMap<&str, &sps_core::installed::InstalledPackageInfo> =
-                HashMap::new();
-            for pkg in &installed {
-                match pkg.pkg_type {
-                    PackageType::Formula => {
-                        let entry = formula_map.entry(pkg.name.as_str()).or_insert(pkg);
-                        // Compare version strings lexicographically (should be semver, but for now
-                        // string)
-                        if pkg.version > entry.version {
-                            formula_map.insert(pkg.name.as_str(), pkg);
-                        }
+        // Only show the latest version for each name
+        use std::collections::HashMap;
+        let mut formula_map: HashMap<&str, &sps_core::installed::InstalledPackageInfo> =
+            HashMap::new();
+        let mut cask_map: HashMap<&str, &sps_core::installed::InstalledPackageInfo> =
+            HashMap::new();
+        for pkg in &installed {
+            match pkg.pkg_type {
+                PackageType::Formula => {
+                    let entry = formula_map.entry(pkg.name.as_str()).or_insert(pkg);
+                    if pkg.version > entry.version {
+                        formula_map.insert(pkg.name.as_str(), pkg);
                     }
-                    PackageType::Cask => {
-                        let entry = cask_map.entry(pkg.name.as_str()).or_insert(pkg);
-                        if pkg.version > entry.version {
-                            cask_map.insert(pkg.name.as_str(), pkg);
-                        }
+                }
+                PackageType::Cask => {
+                    let entry = cask_map.entry(pkg.name.as_str()).or_insert(pkg);
+                    if pkg.version > entry.version {
+                        cask_map.insert(pkg.name.as_str(), pkg);
                     }
                 }
             }
-            formulas = formula_map.values().copied().collect();
-            casks = cask_map.values().copied().collect();
         }
+        let mut formulas: Vec<&InstalledPackageInfo> = formula_map.values().copied().collect();
+        let mut casks: Vec<&InstalledPackageInfo> = cask_map.values().copied().collect();
         // Sort formulas and casks alphabetically by name, then version
         formulas.sort_by(|a, b| a.name.cmp(&b.name).then(a.version.cmp(&b.version)));
         casks.sort_by(|a, b| a.name.cmp(&b.name).then(a.version.cmp(&b.version)));
+        // If Nothing Installed.
         if formulas.is_empty() && casks.is_empty() {
             println!("{}", "0 formulas and casks installed".yellow());
             return Ok(());
         }
+        // If user wants to show installed formulas only.
+        if self.formula_only {
+            self.print_formulas_table(formulas, config);
+            return Ok(());
+        }
+        // If user wants to show installed casks only.
+        if self.cask_only {
+            self.print_casks_table(casks, cache);
+            return Ok(());
+        }
+
+        // Default Implementation
         let formulary = Formulary::new(config.clone());
         let mut table = Table::new();
         table.set_format(*format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR);
@@ -72,7 +75,7 @@ impl List {
             Cell::new("Type").style_spec("b"),
             Cell::new("Name").style_spec("b"),
             Cell::new("Installed").style_spec("b"),
-            Cell::new("New?").style_spec("b"),
+            Cell::new("New Version?").style_spec("b"),
         ]));
         let mut formula_count = 0;
         let mut cask_count = 0;
@@ -130,5 +133,100 @@ impl List {
             println!("{}", format!("{cask_count} casks installed").bold());
         }
         Ok(())
+    }
+
+    fn print_formulas_table(
+        &self,
+        formulas: Vec<&sps_core::installed::InstalledPackageInfo>,
+        config: &Config,
+    ) {
+        if formulas.is_empty() {
+            println!("No formulas installed.");
+            return;
+        }
+        let formulary = Formulary::new(config.clone());
+        let mut table = Table::new();
+        table.set_format(*format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR);
+        // Add header row with "Formulas" spanning all columns, font color green
+        table.add_row(Row::new(vec![Cell::new_align(
+            "Formulas",
+            format::Alignment::CENTER,
+        )
+        .style_spec("bFg")
+        .with_hspan(3)]));
+        table.add_row(Row::new(vec![
+            Cell::new("Name").style_spec("b"),
+            Cell::new("Installed").style_spec("b"),
+            Cell::new("New Version?").style_spec("b"),
+        ]));
+        let mut formula_count = 0;
+        for pkg in formulas {
+            let latest = formulary.load_formula(&pkg.name).ok();
+            let (has_new, _) = match latest {
+                Some(ref f) => {
+                    let latest_version = f.version_str_full();
+                    (latest_version != pkg.version, latest_version)
+                }
+                None => (false, "-".to_string()),
+            };
+            table.add_row(Row::new(vec![
+                Cell::new(&pkg.name).style_spec("Fb"),
+                Cell::new(&pkg.version),
+                Cell::new(if has_new { "✔" } else { "" }),
+            ]));
+            formula_count += 1;
+        }
+        table.printstd();
+        println!("{}", format!("{formula_count} formulas installed").bold());
+    }
+
+    fn print_casks_table(
+        &self,
+        casks: Vec<&sps_core::installed::InstalledPackageInfo>,
+        cache: Arc<Cache>,
+    ) {
+        if casks.is_empty() {
+            println!("No casks installed.");
+            return;
+        }
+        let mut table = Table::new();
+        table.set_format(*format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR);
+        // Add header row with "Casks" spanning all columns, font color green
+        table.add_row(Row::new(vec![Cell::new_align(
+            "Casks",
+            format::Alignment::CENTER,
+        )
+        .style_spec("bFg")
+        .with_hspan(3)]));
+        table.add_row(Row::new(vec![
+            Cell::new("Name").style_spec("b"),
+            Cell::new("Installed").style_spec("b"),
+            Cell::new("New Version?").style_spec("b"),
+        ]));
+        let mut cask_count = 0;
+        for pkg in casks {
+            // Try to load cask info from cache
+            let cask_val = cache.load_raw("cask.json").ok().and_then(|raw| {
+                serde_json::from_str::<Vec<Value>>(&raw)
+                    .ok()?
+                    .into_iter()
+                    .find(|v| v.get("token").and_then(|t| t.as_str()) == Some(&pkg.name))
+            });
+            let (has_new, _) = match cask_val {
+                Some(ref v) => {
+                    let latest_version = v.get("version").and_then(|v| v.as_str()).unwrap_or("-");
+                    (latest_version != pkg.version, latest_version.to_string())
+                }
+                None => (false, "-".to_string()),
+            };
+            table.add_row(Row::new(vec![
+                Cell::new(&pkg.name).style_spec("Fb"),
+                Cell::new(&pkg.version),
+                Cell::new(if has_new { "✔" } else { "" }),
+            ]));
+            cask_count += 1;
+        }
+        table.printstd();
+        println!("{}", format!("{cask_count} casks installed").bold());
     }
 }

--- a/sps/src/cli/list.rs
+++ b/sps/src/cli/list.rs
@@ -1,0 +1,127 @@
+use std::sync::Arc;
+
+use clap::Args;
+use colored::Colorize;
+use prettytable::{format, Cell, Row, Table};
+use sps_common::cache::Cache;
+use sps_common::config::Config;
+use sps_common::error::Result;
+use sps_core::installed::{get_installed_packages, PackageType};
+use sps_common::formulary::Formulary;
+use serde_json::Value;
+
+#[derive(Args, Debug)]
+pub struct List {
+    /// Show all installed versions, not just the latest for each name
+    #[arg(long)]
+    pub all: bool,
+}
+
+impl List {
+    pub async fn run(&self, config: &Config, cache: Arc<Cache>) -> Result<()> {
+        let installed = get_installed_packages(config).await?;
+        let mut formulas = Vec::new();
+        let mut casks = Vec::new();
+        if self.all {
+            // Show all installed versions
+            for pkg in &installed {
+                match pkg.pkg_type {
+                    PackageType::Formula => formulas.push(pkg),
+                    PackageType::Cask => casks.push(pkg),
+                }
+            }
+        } else {
+            // Only show the latest version for each name
+            use std::collections::HashMap;
+            let mut formula_map: HashMap<&str, &sps_core::installed::InstalledPackageInfo> = HashMap::new();
+            let mut cask_map: HashMap<&str, &sps_core::installed::InstalledPackageInfo> = HashMap::new();
+            for pkg in &installed {
+                match pkg.pkg_type {
+                    PackageType::Formula => {
+                        let entry = formula_map.entry(pkg.name.as_str()).or_insert(pkg);
+                        // Compare version strings lexicographically (should be semver, but for now string)
+                        if pkg.version > entry.version {
+                            formula_map.insert(pkg.name.as_str(), pkg);
+                        }
+                    }
+                    PackageType::Cask => {
+                        let entry = cask_map.entry(pkg.name.as_str()).or_insert(pkg);
+                        if pkg.version > entry.version {
+                            cask_map.insert(pkg.name.as_str(), pkg);
+                        }
+                    }
+                }
+            }
+            formulas = formula_map.values().copied().collect();
+            casks = cask_map.values().copied().collect();
+        }
+        // Sort formulas and casks alphabetically by name, then version
+        formulas.sort_by(|a, b| a.name.cmp(&b.name).then(a.version.cmp(&b.version)));
+        casks.sort_by(|a, b| a.name.cmp(&b.name).then(a.version.cmp(&b.version)));
+        if formulas.is_empty() && casks.is_empty() {
+            println!("{}", "0 formulas and casks installed".yellow());
+            return Ok(());
+        }
+        let formulary = Formulary::new(config.clone());
+        let mut table = Table::new();
+        table.set_format(*format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR);
+        table.add_row(Row::new(vec![
+            Cell::new("Type").style_spec("b"),
+            Cell::new("Name").style_spec("b"),
+            Cell::new("Installed").style_spec("b"),
+            Cell::new("New?").style_spec("b"),
+        ]));
+        let mut formula_count = 0;
+        let mut cask_count = 0;
+        for pkg in formulas {
+            let latest = formulary.load_formula(&pkg.name).ok();
+            let (has_new, latest_version) = match latest {
+                Some(ref f) => {
+                    let latest_version = f.version_str_full();
+                    (latest_version != pkg.version, latest_version)
+                }
+                None => (false, "-".to_string()),
+            };
+            table.add_row(Row::new(vec![
+                Cell::new("Formula").style_spec("Fg"),
+                Cell::new(&pkg.name).style_spec("Fb"),
+                Cell::new(&pkg.version),
+                // TODO: update to display the latest version string.
+                // TODO: Not showing when the using --all flag.
+                Cell::new(if has_new { "✔" } else { "" }),
+            ]));
+            formula_count += 1;
+        }
+        for pkg in casks {
+            // Try to load cask info from cache
+            let cask_val = cache.load_raw("cask.json").ok().and_then(|raw| {
+                serde_json::from_str::<Vec<Value>>(&raw).ok()?.into_iter().find(|v| {
+                    v.get("token").and_then(|t| t.as_str()) == Some(&pkg.name)
+                })
+            });
+            let (has_new, latest_version) = match cask_val {
+                Some(ref v) => {
+                    let latest_version = v.get("version").and_then(|v| v.as_str()).unwrap_or("-");
+                    (latest_version != pkg.version, latest_version.to_string())
+                }
+                None => (false, "-".to_string()),
+            };
+            table.add_row(Row::new(vec![
+                Cell::new("Cask").style_spec("Fy"),
+                Cell::new(&pkg.name).style_spec("Fb"),
+                Cell::new(&pkg.version),
+                Cell::new(if has_new { "✔" } else { "" }),
+            ]));
+            cask_count += 1;
+        }
+        table.printstd();
+        if formula_count > 0 && cask_count > 0 {
+            println!("{}", format!("{formula_count} formulas, {cask_count} casks installed").bold());
+        } else if formula_count > 0 {
+            println!("{}", format!("{formula_count} formulas installed").bold());
+        } else if cask_count > 0 {
+            println!("{}", format!("{cask_count} casks installed").bold());
+        }
+        Ok(())
+    }
+}

--- a/sps/src/cli/list.rs
+++ b/sps/src/cli/list.rs
@@ -78,7 +78,7 @@ impl List {
         let mut cask_count = 0;
         for pkg in formulas {
             let latest = formulary.load_formula(&pkg.name).ok();
-            let (has_new, latest_version) = match latest {
+            let (has_new, _) = match latest {
                 Some(ref f) => {
                     let latest_version = f.version_str_full();
                     (latest_version != pkg.version, latest_version)
@@ -103,7 +103,7 @@ impl List {
                     .into_iter()
                     .find(|v| v.get("token").and_then(|t| t.as_str()) == Some(&pkg.name))
             });
-            let (has_new, latest_version) = match cask_val {
+            let (has_new, _) = match cask_val {
                 Some(ref v) => {
                     let latest_version = v.get("version").and_then(|v| v.as_str()).unwrap_or("-");
                     (latest_version != pkg.version, latest_version.to_string())


### PR DESCRIPTION
This is a draft PR that aims to solve the request of #43. 

### Why create this PR?
Currently, there is no command that allows user to check installed formulas and casks. Therefore I added a command handle this kind of situation. I am also planning to add indicators 

### Why it is a draft?
There are several reasons to make it as a draft, instead of a proper PR:
- the core part of codebase is currently under active development and refactoring (which is definitely having a higher priority in my opinion.)
- I am still not sure if "list" is a good name for this command (Yeah, the naming issues.)
- I want to add and refine a bit more on the current code.

### Usage
- `sps list`: It will show all the formulas and casks, with their latest installed version.
- `sps list --all`: With the `all` flag, all the installed formulas and casks will be shown.

Feel free to give comments and review the code!
